### PR TITLE
Bump version to 1.4.81

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {%set name = "botocore" %}
-{%set version = "1.4.49" %}
+{%set version = "1.4.81" %}
 {%set hash_type = "sha256" %}
-{%set hash_val = "c7804efb622f340593ae49cc552481f2820de2088199a0010d469cf0dfb94731" %}
+{%set hash_val = "e8e0e462a45c4b34fd1f018564459b739ec0bb7fbb3358a0e2d8f27b7bf7341f" %}
 
 package:
   name: {{ name }}
@@ -61,3 +61,4 @@ about:
 extra:
   recipe-maintainers:
     - pmlandwehr
+    - hajapy


### PR DESCRIPTION
I am interested in getting a more up to date awscli on conda-forge. This requires s3transfer to get to 0.1.9 (already an open PR https://github.com/conda-forge/s3transfer-feedstock/pull/5), botocore to 1.4.81 (this PR) and then awscli can be updated to 1.11.24 (upcoming PR once this botocore becomes available). 

Note that currently awscli on conda-forge is pinned to s3transfer 0.0.1: https://github.com/conda-forge/awscli-feedstock/blob/master/recipe/meta.yaml